### PR TITLE
bugfix: initted breaks getTitle / setTitle

### DIFF
--- a/controllers/widget.js
+++ b/controllers/widget.js
@@ -65,6 +65,8 @@ function applyProperties(properties) {
 
   //Ti.API.info("_applyProperties2:"+JSON.stringify(_properties));
   _applyProperties(_properties);
+  
+  _initted = true;
 }
 
 function setTitle(title) {


### PR DESCRIPTION
if `_initted` is never set to true it's an unused var, setting it to `true`enables button functionality
